### PR TITLE
Use launch files for all AWS Cloud Extensions

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -12,5 +12,5 @@
 - git: {local-name: src/deps/kinesisvideo-common, uri: 'https://github.com/aws-robotics/kinesisvideo-common', version: v1.0.0}
 - git: {local-name: src/deps/kinesisvideo-ros1, uri: 'https://github.com/aws-robotics/kinesisvideo-ros1', version: v1.0.0}
 - git: {local-name: src/deps/kinesisvideo-encoder-common, uri: 'https://github.com/aws-robotics/kinesisvideo-encoder-common', version: v1.0.0}
-- git: {local-name: src/deps/kinesisvideo-encoder-ros1, uri: 'https://github.com/aws-robotics/kinesisvideo-encoder-ros1', version: v1.0.0}
+- git: {local-name: src/deps/kinesisvideo-encoder-ros1, uri: 'https://github.com/aws-robotics/kinesisvideo-encoder-ros1', version: v1.1.0}
 - git: {local-name: src/deps/tts-ros1, uri: 'https://github.com/aws-robotics/tts-ros1', version: v1.0.0}

--- a/robot_ws/src/person_detection_robot/launch/kinesis.launch
+++ b/robot_ws/src/person_detection_robot/launch/kinesis.launch
@@ -25,16 +25,17 @@
     <arg name="config_file" value="$(find person_detection_robot)/config/h264_encoder_config.yaml"/>
     <arg name="image_transport" value="raw"/>
   </include>
-  <rosparam if="$(eval image_topic != '')" param="/$(arg param_prefix)/subscription_topic" subst_value="true">$(arg image_topic)</rosparam>
 
   <include file="$(find kinesis_video_streamer)/launch/kinesis_video_streamer.launch" >
     <!-- The configuration can either be passed in using the "config_file" parameter or by using a rosparam tag
             to load the config into the parameter server -->
+    <arg name="node_name" value="$(arg node_name)"/>
     <arg name="config_file" value="$(arg stream_config)"/>
   </include>
   <param name="/kinesis_video_streamer/aws_client_configuration/region" value="$(arg aws_region)" />
   <param name="/kinesis_video_streamer/kinesis_video/log4cplus_config" value="$(find kinesis_video_streamer)/kvs_log_configuration" />
   <param name="/kinesis_video_streamer/kinesis_video/stream_count" value="1" />
+  <rosparam if="$(eval image_topic != '')" param="/$(arg param_prefix)/subscription_topic" subst_value="true">$(arg image_topic)</rosparam>
   <rosparam if="$(eval launch_id != '')" param="/$(arg param_prefix)/rekognition_data_stream" subst_value="true">$(arg rekognition_data_stream)-$(arg launch_id)</rosparam>
   <rosparam if="$(eval launch_id != '')" param="/$(arg param_prefix)/stream_name" subst_value="true">$(arg stream_name)-$(arg launch_id)</rosparam>
 </launch>

--- a/robot_ws/src/person_detection_robot/launch/kinesis.launch
+++ b/robot_ws/src/person_detection_robot/launch/kinesis.launch
@@ -20,20 +20,22 @@
   <arg name="node_namespace" default="kinesis_video/stream0" />
   <arg name="param_prefix" default="$(arg node_name)/$(arg node_namespace)" />
 
- <!--Launch encoder node for kinesis video stream-->
-  <node pkg="h264_video_encoder" type="h264_video_encoder" name="h264_video_encoder">
-    <rosparam command="load" file="$(find person_detection_robot)/config/h264_encoder_config.yaml"/>
-    <param name="image_transport" value="raw"/>
-    <rosparam if="$(eval image_topic != '')" param="/$(arg param_prefix)/subscription_topic" subst_value="true">$(arg image_topic)</rosparam>
-  </node>
+  <!--Launch encoder node for kinesis video stream-->
+  <include file="$(find h264_video_encoder)/launch/h264_video_encoder.launch">
+    <arg name="config_file" value="$(find person_detection_robot)/config/h264_encoder_config.yaml"/>
+    <arg name="image_transport" value="raw"/>
+  </include>
+  <rosparam if="$(eval image_topic != '')" param="/$(arg param_prefix)/subscription_topic" subst_value="true">$(arg image_topic)</rosparam>
 
-  <node name="$(arg node_name)" pkg="kinesis_video_streamer" type="kinesis_video_streamer">
-    <param name="aws_client_configuration/region" value="$(arg aws_region)" />
-    <param name="kinesis_video/log4cplus_config" value="$(find kinesis_video_streamer)/kvs_log_configuration" />
-    <param name="kinesis_video/stream_count" value="1" />
-    <rosparam if="$(eval stream_config!='')" command="load" file="$(arg stream_config)" ns="$(arg node_namespace)" />
-    <rosparam if="$(eval launch_id != '')" param="/$(arg param_prefix)/rekognition_data_stream" subst_value="true">$(arg rekognition_data_stream)-$(arg launch_id)</rosparam>
-    <rosparam if="$(eval launch_id != '')" param="/$(arg param_prefix)/stream_name" subst_value="true">$(arg stream_name)-$(arg launch_id)</rosparam>
-  </node>
+  <include file="$(find kinesis_video_streamer)/launch/kinesis_video_streamer.launch" >
+    <!-- The configuration can either be passed in using the "config_file" parameter or by using a rosparam tag
+            to load the config into the parameter server -->
+    <arg name="config_file" value="$(arg stream_config)"/>
+  </include>
+  <param name="/kinesis_video_streamer/aws_client_configuration/region" value="$(arg aws_region)" />
+  <param name="/kinesis_video_streamer/kinesis_video/log4cplus_config" value="$(find kinesis_video_streamer)/kvs_log_configuration" />
+  <param name="/kinesis_video_streamer/kinesis_video/stream_count" value="1" />
+  <rosparam if="$(eval launch_id != '')" param="/$(arg param_prefix)/rekognition_data_stream" subst_value="true">$(arg rekognition_data_stream)-$(arg launch_id)</rosparam>
+  <rosparam if="$(eval launch_id != '')" param="/$(arg param_prefix)/stream_name" subst_value="true">$(arg stream_name)-$(arg launch_id)</rosparam>
 </launch>
 

--- a/robot_ws/src/person_detection_robot/launch/monitoring.launch
+++ b/robot_ws/src/person_detection_robot/launch/monitoring.launch
@@ -14,9 +14,9 @@
 
   <!-- Enable CloudWatch logging, send /rosout to CW Logs -->
   <arg name="log_group_name" default="robomaker_person_detection_example" />
-  <node pkg="cloudwatch_logger" type="cloudwatch_logger" name="cloudwatch_logger">
-    <rosparam command="load" file="$(find person_detection_robot)/config/cloudwatch_logs_config.yaml" />
-    <rosparam if="$(eval aws_region != '')" param="/cloudwatch_logger/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
-    <rosparam if="$(eval launch_id != '')" param="/cloudwatch_logger/log_group_name" subst_value="true">$(arg log_group_name)-$(arg launch_id)</rosparam>
-  </node>
+  <include file="$(find cloudwatch_logger)/launch/cloudwatch_logger.launch">
+    <arg name="config_file" value="$(find person_detection_robot)/config/cloudwatch_logs_config.yaml" />
+  </include>
+  <rosparam if="$(eval aws_region != '')" param="/cloudwatch_logger/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
+  <rosparam if="$(eval launch_id != '')" param="/cloudwatch_logger/log_group_name" subst_value="true">$(arg log_group_name)-$(arg launch_id)</rosparam>
 </launch>

--- a/robot_ws/src/person_detection_robot/launch/monitoring.launch
+++ b/robot_ws/src/person_detection_robot/launch/monitoring.launch
@@ -11,12 +11,15 @@
 
   <!-- Optional launch ID, if specified, used for suffixing resource names -->
   <arg name="launch_id" value="$(optenv LAUNCH_ID)" doc="Used for resource name suffix if specified"/>
+  
+  <arg name="node_name" value="cloudwatch_logger"/>
 
   <!-- Enable CloudWatch logging, send /rosout to CW Logs -->
-  <arg name="log_group_name" default="robomaker_person_detection_example" />
+  <arg name="log_group_name" default="robomaker_person_detection_example"/>
   <include file="$(find cloudwatch_logger)/launch/cloudwatch_logger.launch">
-    <arg name="config_file" value="$(find person_detection_robot)/config/cloudwatch_logs_config.yaml" />
+    <arg name="config_file" value="$(find person_detection_robot)/config/cloudwatch_logs_config.yaml"/>
+    <arg name="node_name" value="$(arg node_name)"/>
   </include>
-  <rosparam if="$(eval aws_region != '')" param="/cloudwatch_logger/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
-  <rosparam if="$(eval launch_id != '')" param="/cloudwatch_logger/log_group_name" subst_value="true">$(arg log_group_name)-$(arg launch_id)</rosparam>
+  <rosparam if="$(eval aws_region != '')" param="/$(arg node_name)/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
+  <rosparam if="$(eval launch_id != '')" param="/$(arg node_name)/log_group_name" subst_value="true">$(arg log_group_name)-$(arg launch_id)</rosparam>
 </launch>


### PR DESCRIPTION
Instead of running the cloud extension nodes directly, include their launch files. This is the recommended way to use them in an application.

To ensure nothing changed I saved the list of PARAMETERS displayed when running `roslaunch person_detection_robot person_detection.launch` for both master and this branch and compared them and they are identical. 

This PR requires https://github.com/aws-robotics/kinesisvideo-encoder-ros1/pull/4 to be merged first to allow the user to change the image transport type. After it is merged it will need to be tagged and then the `~/robot_ws/.rosinstall` file in this sample application must be updated. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
