### PR TITLE
Update CloudWatch Metrics v1.0.1, fix timestamp bug

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -6,7 +6,7 @@
 - git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: v1.0.0}
 - git: {local-name: src/deps/cloudwatch-common, uri: 'https://github.com/aws-robotics/cloudwatch-common', version: v1.0.0}
 - git: {local-name: src/deps/cloudwatchlogs-ros1, uri: 'https://github.com/aws-robotics/cloudwatchlogs-ros1', version: v1.0.0}
-- git: {local-name: src/deps/cloudwatchmetrics-ros1, uri: 'https://github.com/aws-robotics/cloudwatchmetrics-ros1', version: v1.0.0}
+- git: {local-name: src/deps/cloudwatchmetrics-ros1, uri: 'https://github.com/aws-robotics/cloudwatchmetrics-ros1', version: v1.0.1}
 - git: {local-name: src/deps/health-metrics-collector-ros1, uri: 'https://github.com/aws-robotics/health-metrics-collector-ros1', version: v1.0.0}
 - git: {local-name: src/deps/monitoringmessages-ros1, uri: 'https://github.com/aws-robotics/monitoringmessages-ros1', version: v1.0.0}
 - git: {local-name: src/deps/kinesisvideo-common, uri: 'https://github.com/aws-robotics/kinesisvideo-common', version: v1.0.0}


### PR DESCRIPTION
Even though CloudWatch Metrics node is not launched, the .rosinstall does refer to a buggy version (v.1.0.0). This commit updates to a known good version (v1.0.1). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
