### PR TITLE
Add region to deploy to s3 step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ deploy:
     access_key_id: "$AWS_ACCESS_KEY_ID"
     secret_access_key: "$AWS_SECRET_ACCESS_KEY"
     bucket: "$S3_BUCKET_NAME"
+    region: "us-west-2"
     local_dir: shared
     skip_cleanup: true
     wait-until-deployed: true


### PR DESCRIPTION
We've removed some S3 IAM permissions from the TravisCI user which helped Travis redirect to the correct region to deploy to the bucket. Now that they've been removed we need to specify the exact region of the bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
