### PR TITLE
Improve documentation for running on physical robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ Launch the application with the following commands:
 
 - *Running Robot Application on a Robot*
 
-    Once the bundle has been created, it can be deployed using RoboMaker. For information about deploying using RoboMaker, see [this documentation](https://docs.aws.amazon.com/robomaker/latest/dg/gs-deploy.html).
+    Once the bundle has been created, it can be deployed using RoboMaker. For information about deploying using RoboMaker, see [this documentation](https://docs.aws.amazon.com/robomaker/latest/dg/gs-deploy.html). You can follow those instructions
+    to cross-compile the sample application for the ARMHF architecture supported by the Raspberry PI, using a RoboMaker
+    Development environment.
 
     You must also complete the Raspberry Pi camera setup for the TurtleBot WafflePi, outlined
     [here](http://emanual.robotis.com/docs/en/platform/turtlebot3/appendix_raspi_cam/#raspberry-pi-camera).
@@ -129,10 +131,19 @@ Launch the application with the following commands:
     You may also upload and run the bundle manually. Once the bundle has been manually uploaded to the target TurtleBot WafflePi, ssh into the TurtleBot and run
 
     ```bash
-    export BUNDLE_CURRENT_PREFIX=/path/to/bundle/
-    source $BUNDLE_CURRENT_PREFIX/setup.sh
+    tar xvf robot_ws_armhf_bundle.tar
+    mkdir dependencies && tar xvzf dependencies.tar.gz -C dependencies
+    mkdir workspace && tar xvzf workspace.tar.gz -C workspace
+    export LAUNCH_ID=YOUR_LAUNCH_ID
+    BUNDLE_CURRENT_PREFIX=$(pwd)/dependencies source $(pwd)/dependencies/setup.sh
+    BUNDLE_CURRENT_PREFIX=$(pwd)/workspace source $(pwd)/workspace/setup.sh
     roslaunch person_detection_robot deploy_person_detection.launch
     ```
+
+    See the [colcon-bundle documentation](https://github.com/colcon/colcon-bundle#bundle-usage) for more details.
+
+    Finally, note the `width` and `height` parameters for the node `raspicam_node` on `deploy_person_detection.launch` might require
+    some adjustment depending on the resolution of the specific robot camera.
 
 - *Running Robot Application Elsewhere*
     ```bash

--- a/robot_ws/src/person_detection_robot/launch/deploy_person_detection.launch
+++ b/robot_ws/src/person_detection_robot/launch/deploy_person_detection.launch
@@ -4,8 +4,8 @@
 
   <!-- Start getting images from the camera -->
   <node type="raspicam_node" pkg="raspicam_node" name="raspicam_node" output="screen">
-    <param name="width" value="640"/>
-    <param name="height" value="480"/>
+    <param name="width" value="410"/>
+    <param name="height" value="308"/>
  
     <param name="framerate" value="10"/>
     <param name="exposure_mode" value="antishake"/>
@@ -18,4 +18,7 @@
     <arg name="use_polly" value="true" />
     <arg name="image_topic" value="/raspicam_node/image"/>
   </include>
+
+  <rosparam param="/h264_video_encoder/subscription_topic" subst_value="true">/raspicam_node/image</rosparam>
+  <rosparam param="/h264_video_encoder/image_transport" subst_value="true">compressed</rosparam>
 </launch>


### PR DESCRIPTION
*Issue #, if available:*
#22 

*Description of changes:*
This PR tries to improve the documentation for running on a physical robot, by being more explicit about how to manually use a colcon bundle to run it on a robot. 
It also fixes the launch file for physical robots, to use correct parameters for the node `h264_video_encoder` when running on a robot instead of simulation, as the camera is different in that case. 

*Testing*
This has been tested on a turtlebot 3 burger running Ubuntu Mate 16.04.2 (Xenial) and ROS Kinetic

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
