### PR TITLE
Remove setup-file element from robot_ws/.rosinstall

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,6 +1,3 @@
-# kinetic.rosinstall
-- setup-file: {local-name: /opt/ros/kinetic/setup.sh}
-
 # Amazon ROS CloudServiceIntegration package dependencies
 - git: {local-name: src/deps/utils-common, uri: 'https://github.com/aws-robotics/utils-common', version: v1.0.0}
 - git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: v1.0.0}


### PR DESCRIPTION
Not needed and will just confuse customers as we also support Melodic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
