### PR TITLE
Fix incorrect arguments name, type, and context in multiple launch files

### DIFF
--- a/robot_ws/src/person_detection_robot/launch/kinesis.launch
+++ b/robot_ws/src/person_detection_robot/launch/kinesis.launch
@@ -24,18 +24,18 @@
   <include file="$(find h264_video_encoder)/launch/h264_video_encoder.launch">
     <arg name="config_file" value="$(find person_detection_robot)/config/h264_encoder_config.yaml"/>
     <arg name="image_transport" value="raw"/>
+    <rosparam if="$(eval image_topic != '')" param="/$(arg param_prefix)/subscription_topic" subst_value="true">$(arg image_topic)</rosparam>
   </include>
 
   <include file="$(find kinesis_video_streamer)/launch/kinesis_video_streamer.launch" >
     <!-- The configuration can either be passed in using the "config_file" parameter or by using a rosparam tag
             to load the config into the parameter server -->
     <arg name="node_name" value="$(arg node_name)"/>
-    <arg name="config_file" value="$(arg stream_config)"/>
+    <arg name="stream_config_file" value="$(arg stream_config)"/>
   </include>
   <param name="/kinesis_video_streamer/aws_client_configuration/region" value="$(arg aws_region)" />
   <param name="/kinesis_video_streamer/kinesis_video/log4cplus_config" value="$(find kinesis_video_streamer)/kvs_log_configuration" />
   <param name="/kinesis_video_streamer/kinesis_video/stream_count" value="1" />
-  <rosparam if="$(eval image_topic != '')" param="/$(arg param_prefix)/subscription_topic" subst_value="true">$(arg image_topic)</rosparam>
   <rosparam if="$(eval launch_id != '')" param="/$(arg param_prefix)/rekognition_data_stream" subst_value="true">$(arg rekognition_data_stream)-$(arg launch_id)</rosparam>
   <rosparam if="$(eval launch_id != '')" param="/$(arg param_prefix)/stream_name" subst_value="true">$(arg stream_name)-$(arg launch_id)</rosparam>
 </launch>

--- a/robot_ws/src/person_detection_robot/launch/person_detection.launch
+++ b/robot_ws/src/person_detection_robot/launch/person_detection.launch
@@ -16,7 +16,7 @@
        See its .launch file for parameterizing AWS region and resource names
    -->
   <include file="$(find person_detection_robot)/launch/kinesis.launch">
-    <param name="image_topic" value="$(arg image_topic)"/>
+    <arg name="image_topic" value="$(arg image_topic)"/>
   </include>
 
   <!-- Launch node to extract names from Rekognition results. Sends Polly/voice requests. -->


### PR DESCRIPTION
*Issue #29 

*Description of changes:*

- `kinesis_video_streamer.launch` receives a `stream_config_file`, not `config_file`
- `arg` is the correct element type to use when passing arguments to included files, not `param`
- `subscription_topic` was set for the entire global context of the launch file, affecting both kinesis_video_streamer and h264_encoder and having them both subscribe to `raspicam_node/image`. Only the encoder should subscribe to `raspicam_node/image`. I'm not sure the change I made is what we want though, it probably isn't (it just reverts to the state before https://github.com/aws-robotics/aws-robomaker-sample-application-persondetection/pull/4). Need to rethink and review this more.

Tested it works on TB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
