### PR TITLE
Replace travis_wait with background sleep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ install:
 - git clone https://github.com/aws-robotics/travis-scripts.git .ros_ci
 script:
 - . .ros_ci/add_tag.sh
-- travis_wait 100 .ros_ci/ce_build.sh
+- while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+- .ros_ci/ce_build.sh
+- kill %1
 before_deploy:
 - . .ros_ci/before_deploy.sh
 deploy:


### PR DESCRIPTION
`travis_wait` hides the output so we can't see what failed, e.g. in the following job: https://travis-ci.org/aws-robotics/aws-robomaker-sample-application-persondetection/jobs/548339194

Will do this for other SAs once we confirm the behavior. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
