### PR TITLE
Depend on release-v2 branch of kinesisvideo-common

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -3,7 +3,7 @@
 - git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: 2.0.0}
 - git: {local-name: src/deps/cloudwatch-common, uri: 'https://github.com/aws-robotics/cloudwatch-common', version: 1.0.1}
 - git: {local-name: src/deps/cloudwatchlogs-ros1, uri: 'https://github.com/aws-robotics/cloudwatchlogs-ros1', version: 2.0.0}
-- git: {local-name: src/deps/kinesisvideo-common, uri: 'https://github.com/aws-robotics/kinesisvideo-common', version: 2.0.0}
+- git: {local-name: src/deps/kinesisvideo-common, uri: 'https://github.com/aws-robotics/kinesisvideo-common', version: 021b1a3c2d94440055382fdc0bbf0bf32afdfd9e}
 - git: {local-name: src/deps/kinesisvideo-ros1, uri: 'https://github.com/aws-robotics/kinesisvideo-ros1', version: 2.0.1}
 - git: {local-name: src/deps/kinesisvideo-encoder-common, uri: 'https://github.com/aws-robotics/kinesisvideo-encoder-common', version: 2.0.0}
 - git: {local-name: src/deps/kinesisvideo-encoder-ros1, uri: 'https://github.com/aws-robotics/kinesisvideo-encoder-ros1', version: 1.1.1}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Depend on release-v2 branch of kinesisvideo-common, so we get the update on the checksum for the KVS SDK. Otherwise we get a build error as seem on https://travis-ci.org/aws-robotics/aws-robomaker-sample-application-persondetection/jobs/556938644 

```
Starting >>> kinesis_manager
--- stderr: kinesis_manager
CMake Warning at CMakeLists.txt:61 (message):
  Could not find GTest.  Not building unit tests.


CMake Error at /kinetic_ws/src/aws-robomaker-sample-application-persondetection/robot_ws/build/kinesis_manager/kvssdk/KVS_SDK_IMPORT-prefix/src/KVS_SDK_IMPORT-stamp/verify-KVS_SDK_IMPORT.cmake:27 (message):
  error: MD5 hash of

    /kinetic_ws/src/aws-robomaker-sample-application-persondetection/robot_ws/build/kinesis_manager/kvssdk/KVS_SDK_IMPORT-prefix/src/1.7.8.tar.gz

  does not match expected value

    expected: b8d1ac7ffb3626cb60c7e719edf84006
      actual: 9f3da8e64603198fe20d5c38e4a4cb08



make[2]: *** [kvssdk/KVS_SDK_IMPORT-prefix/src/KVS_SDK_IMPORT-stamp/KVS_SDK_IMPORT-download] Error 1
make[1]: *** [kvssdk/CMakeFiles/KVS_SDK_IMPORT.dir/all] Error 2
```

Note that travis job still passes, I'll also investigate that later

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
