### PR TITLE
Adds timestamps to ce_build.sh output in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
   - GH_USER_EMAIL="travis@travis-ci.org"
   - AWS_DEFAULT_REGION=us-west-2
 before_install:
+- sudo apt update && sudo apt install moreutils
 - pip install --user awscli
 - openssl aes-256-cbc -K $encrypted_13642953d095_key -iv $encrypted_13642953d095_iv
   -in github_deploy.pem.enc -out github_deploy.pem -d
@@ -31,7 +32,7 @@ install:
 script:
 - . .ros_ci/add_tag.sh
 - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
-- .ros_ci/ce_build.sh
+- .ros_ci/ce_build.sh | ts -s "%.s"
 - kill %1
 before_deploy:
 - . .ros_ci/before_deploy.sh


### PR DESCRIPTION
To make it easier to figure out what takes up time in ce_build.sh, this
adds timestamps starting at 0 to each line printed from ce_build.sh.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
