### PR TITLE
Updating .rosinstall to use the release-latest of dependencies

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,10 +1,10 @@
 # Amazon ROS CloudServiceIntegration package dependencies
-- git: {local-name: src/deps/utils-common, uri: 'https://github.com/aws-robotics/utils-common', version: 2.0.0}
-- git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: 2.0.0}
-- git: {local-name: src/deps/cloudwatch-common, uri: 'https://github.com/aws-robotics/cloudwatch-common', version: 1.0.1}
-- git: {local-name: src/deps/cloudwatchlogs-ros1, uri: 'https://github.com/aws-robotics/cloudwatchlogs-ros1', version: 2.0.0}
-- git: {local-name: src/deps/kinesisvideo-common, uri: 'https://github.com/aws-robotics/kinesisvideo-common', version: 021b1a3c2d94440055382fdc0bbf0bf32afdfd9e}
-- git: {local-name: src/deps/kinesisvideo-ros1, uri: 'https://github.com/aws-robotics/kinesisvideo-ros1', version: 2.0.1}
-- git: {local-name: src/deps/kinesisvideo-encoder-common, uri: 'https://github.com/aws-robotics/kinesisvideo-encoder-common', version: 2.0.0}
-- git: {local-name: src/deps/kinesisvideo-encoder-ros1, uri: 'https://github.com/aws-robotics/kinesisvideo-encoder-ros1', version: 1.1.1}
-- git: {local-name: src/deps/tts-ros1, uri: 'https://github.com/aws-robotics/tts-ros1', version: 1.0.1}
+- git: {local-name: src/deps/utils-common, uri: 'https://github.com/aws-robotics/utils-common', version: 'release-latest'}
+- git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/cloudwatch-common, uri: 'https://github.com/aws-robotics/cloudwatch-common', version: 'release-latest'}
+- git: {local-name: src/deps/cloudwatchlogs-ros1, uri: 'https://github.com/aws-robotics/cloudwatchlogs-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/kinesisvideo-common, uri: 'https://github.com/aws-robotics/kinesisvideo-common', version: 'release-latest'}
+- git: {local-name: src/deps/kinesisvideo-ros1, uri: 'https://github.com/aws-robotics/kinesisvideo-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/kinesisvideo-encoder-common, uri: 'https://github.com/aws-robotics/kinesisvideo-encoder-common', version: 'release-latest'}
+- git: {local-name: src/deps/kinesisvideo-encoder-ros1, uri: 'https://github.com/aws-robotics/kinesisvideo-encoder-ros1', version: 'release-latest'}
+- git: {local-name: src/deps/tts-ros1, uri: 'https://github.com/aws-robotics/tts-ros1', version: 'release-latest'}


### PR DESCRIPTION
*Issue #, if available:*
See comments here: https://github.com/aws-robotics/aws-robomaker-sample-application-cloudwatch/pull/30
tt: P26480778

*Description of changes:*
Updating .rosinstall to use the release-latest of dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
